### PR TITLE
Update CmTransactionalTransport.php

### DIFF
--- a/src/CmTransactionalAdapter.php
+++ b/src/CmTransactionalAdapter.php
@@ -87,7 +87,7 @@ class CmTransactionalAdapter extends BaseTransportAdapter
     public function defineTransport()
     {
 
-        $auth = array('api_key' => $this->apiKey);
+        $auth = array('api_key' => Craft::parseEnv($this->apiKey));
         $client = new \CS_REST_General($auth);
 
         return new CmTransactionalTransport($auth);

--- a/src/CmTransactionalTransport.php
+++ b/src/CmTransactionalTransport.php
@@ -54,7 +54,7 @@ class CmTransactionalTransport extends Transport
         $groupName = 'Craft CMS';
 
         try {
-            $result = $classicEmail->send($data, $groupName);
+            $result = $classicEmail->send($data, $groupName, 'Unchanged');
             // echo "\nSent! Here's the response:\n";
             // var_dump($result->response); exit;
         }

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -1,12 +1,15 @@
 {% import "_includes/forms" as forms %}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     label: "API Key (or Client API Key)"|t('cm-transactional'),
     instructions: "You can find this in your Campaign Monitor settings."|t('cm-transactional'),
     id: 'apiKey',
     name: 'apiKey',
     value: adapter.apiKey,
-    errors: adapter.getErrors('apiKey')
+    errors: adapter.getErrors('apiKey'),
+    suggestEnvVars: true,
+    suggestions: craft.cp.getEnvSuggestions(),
+    required: true
 }) }}
 
 {#


### PR DESCRIPTION
Got an error on my end because the third parameter here was omitted and mandatory. I think setting it to 'Unchanged' is the best way to go, see: https://www.campaignmonitor.com/api/transactional/#send-classic-email