### PR TITLE
Add Group Name field

### DIFF
--- a/src/CmTransactionalAdapter.php
+++ b/src/CmTransactionalAdapter.php
@@ -47,6 +47,11 @@ class CmTransactionalAdapter extends BaseTransportAdapter
      */
     public $clientId;
 
+    /**
+     * @var string The groupName that should be used
+     */
+    public $groupName;
+
     // Public Methods
     // =========================================================================
 
@@ -88,8 +93,9 @@ class CmTransactionalAdapter extends BaseTransportAdapter
     {
 
         $auth = array('api_key' => Craft::parseEnv($this->apiKey));
+        $groupName = Craft::parseEnv($this->groupName);
         $client = new \CS_REST_General($auth);
 
-        return new CmTransactionalTransport($auth);
+        return new CmTransactionalTransport($auth, $groupName);
     }
 }

--- a/src/CmTransactionalTransport.php
+++ b/src/CmTransactionalTransport.php
@@ -44,7 +44,7 @@ class CmTransactionalTransport extends Transport
      *
      * @param Array $auth
      */
-    public function __construct(Array $auth, String $groupName)
+    public function __construct(Array $auth, $groupName = null)
     {
         $this->_auth = $auth;
         $this->_groupName = $groupName;
@@ -57,7 +57,7 @@ class CmTransactionalTransport extends Transport
     {
         $data = $this->_formatMessage($message);
         $classicEmail = new \CS_REST_Transactional_ClassicEmail($this->_auth, NULL);
-        $groupName = empty($this->_groupName) ?  'Craft CMS' : $this->_groupName;
+        $groupName = (isset($this->_groupName) && !empty($this->_groupName)) ? $this->_groupName : 'Craft CMS';
 
         try {
             $result = $classicEmail->send($data, $groupName, 'Unchanged');

--- a/src/CmTransactionalTransport.php
+++ b/src/CmTransactionalTransport.php
@@ -31,6 +31,11 @@ class CmTransactionalTransport extends Transport
      */
     private $_auth;
 
+    /**
+     * @var String
+     */
+    private $_groupName;
+
     // Public Methods
     // =========================================================================
 
@@ -39,9 +44,10 @@ class CmTransactionalTransport extends Transport
      *
      * @param Array $auth
      */
-    public function __construct(Array $auth)
+    public function __construct(Array $auth, String $groupName)
     {
         $this->_auth = $auth;
+        $this->_groupName = $groupName;
     }
 
     /**
@@ -51,7 +57,7 @@ class CmTransactionalTransport extends Transport
     {
         $data = $this->_formatMessage($message);
         $classicEmail = new \CS_REST_Transactional_ClassicEmail($this->_auth, NULL);
-        $groupName = 'Craft CMS';
+        $groupName = empty($this->_groupName) ?  'Craft CMS' : $this->_groupName;
 
         try {
             $result = $classicEmail->send($data, $groupName, 'Unchanged');

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -12,6 +12,18 @@
     required: true
 }) }}
 
+{{ forms.autosuggestField({
+    label: "Group Name"|t('cm-transactional'),
+    instructions: "The name under which emails are grouped in Campaign Monitor (fallbacks to 'Craft CMS')"|t('cm-transactional'),
+    id: 'groupName',
+    name: 'groupName',
+    value: adapter.groupName,
+    errors: adapter.getErrors('groupName'),
+    suggestEnvVars: true,
+    suggestions: craft.cp.getEnvSuggestions(),
+    required: false
+}) }}
+
 {#
 {{ forms.textField({
     label: "Client ID"|t('cm-transactional'),


### PR DESCRIPTION
For a project we use, we needed the ability to update the group name in Campaign Monitor so we can better filter out some emails. I've updated the adapter for the optional extra field. It fallbacks to the default name (which was just 'Craft CMS').